### PR TITLE
Fix #101: guard recaptcha when keys are missing

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -29,7 +29,16 @@ class ApplicationController < ActionController::Base
 
   def captcha_required?
     default = Rails.env.production? || Rails.env.staging?
-    ActiveModel::Type::Boolean.new.cast(ENV.fetch("RECAPTCHA_ENABLED", default))
+    enabled = ActiveModel::Type::Boolean.new.cast(ENV.fetch("RECAPTCHA_ENABLED", default))
+    return false unless enabled
+    return true if recaptcha_configured?
+
+    Rails.logger.warn("[captcha] RECAPTCHA is enabled but missing site/secret keys. Captcha protection disabled.")
+    false
+  end
+
+  def recaptcha_configured?
+    ENV["RECAPTCHA_SITE_KEY"].present? && ENV["RECAPTCHA_SECRET_KEY"].present?
   end
 
   def invalid_url!

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,7 @@
 # Main application controller
 class ApplicationController < ActionController::Base
   http_basic_authenticate_with name: Rails.application.credentials.http_basic.user, password: Rails.application.credentials.http_basic.password, if: -> { Rails.env.staging? }
+  class_attribute :missing_recaptcha_keys_warning_logged, instance_writer: false, default: false
 
   before_action :redirect_www_to_canonical_host
   before_action :authenticate_user!
@@ -33,12 +34,19 @@ class ApplicationController < ActionController::Base
     return false unless enabled
     return true if recaptcha_configured?
 
-    Rails.logger.warn("[captcha] RECAPTCHA is enabled but missing site/secret keys. Captcha protection disabled.")
+    log_missing_recaptcha_keys_once
     false
   end
 
   def recaptcha_configured?
     ENV["RECAPTCHA_SITE_KEY"].present? && ENV["RECAPTCHA_SECRET_KEY"].present?
+  end
+
+  def log_missing_recaptcha_keys_once
+    return if self.class.missing_recaptcha_keys_warning_logged
+
+    Rails.logger.warn("[captcha] RECAPTCHA is enabled but missing site/secret keys. Captcha protection disabled.")
+    self.class.missing_recaptcha_keys_warning_logged = true
   end
 
   def invalid_url!

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ApplicationController do
+  describe "#captcha_required?" do
+    subject(:captcha_required) { described_class.new.send(:captcha_required?) }
+
+    before do
+      allow(ENV).to receive(:fetch).and_call_original
+      allow(ENV).to receive(:[]).and_call_original
+    end
+
+    context "when captcha is explicitly disabled" do
+      before do
+        allow(ENV).to receive(:fetch).with("RECAPTCHA_ENABLED", anything).and_return("false")
+      end
+
+      it "returns false" do
+        expect(captcha_required).to be(false)
+      end
+    end
+
+    context "when captcha is enabled and keys are present" do
+      before do
+        allow(ENV).to receive(:fetch).with("RECAPTCHA_ENABLED", anything).and_return("true")
+        allow(ENV).to receive(:[]).with("RECAPTCHA_SITE_KEY").and_return("site-key")
+        allow(ENV).to receive(:[]).with("RECAPTCHA_SECRET_KEY").and_return("secret-key")
+      end
+
+      it "returns true" do
+        expect(captcha_required).to be(true)
+      end
+    end
+
+    context "when captcha is enabled but keys are missing" do
+      before do
+        allow(ENV).to receive(:fetch).with("RECAPTCHA_ENABLED", anything).and_return("true")
+        allow(ENV).to receive(:[]).with("RECAPTCHA_SITE_KEY").and_return(nil)
+        allow(ENV).to receive(:[]).with("RECAPTCHA_SECRET_KEY").and_return(nil)
+      end
+
+      it "returns false and logs a warning" do
+        expect(Rails.logger).to receive(:warn).with(/RECAPTCHA is enabled but missing site\/secret keys/)
+        expect(captcha_required).to be(false)
+      end
+    end
+  end
+end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe ApplicationController do
     subject(:captcha_required) { described_class.new.send(:captcha_required?) }
 
     before do
+      described_class.missing_recaptcha_keys_warning_logged = false
       allow(ENV).to receive(:fetch).and_call_original
       allow(ENV).to receive(:[]).and_call_original
     end
@@ -40,8 +41,9 @@ RSpec.describe ApplicationController do
         allow(ENV).to receive(:[]).with("RECAPTCHA_SECRET_KEY").and_return(nil)
       end
 
-      it "returns false and logs a warning" do
+      it "returns false and logs a warning once" do
         expect(Rails.logger).to receive(:warn).with(/RECAPTCHA is enabled but missing site\/secret keys/)
+        expect(captcha_required).to be(false)
         expect(captcha_required).to be(false)
       end
     end


### PR DESCRIPTION
## Summary
- require captcha only when recaptcha is enabled **and** both site/secret keys are configured
- log a warning when captcha is enabled but recaptcha keys are missing
- add spec coverage for `captcha_required?` behavior

## Notes
- this prevents sign-up/sign-in hard failures caused by missing recaptcha key config

Closes #101