### PR TITLE
Fix #47: show sync failures explicitly and finalize failed jobs

### DIFF
--- a/app/consumers/library_sync_consumer.rb
+++ b/app/consumers/library_sync_consumer.rb
@@ -58,7 +58,7 @@ class LibrarySyncConsumer < ApplicationConsumer
     rescue StandardError => e
       mark_sync_job_failed
       Appsignal.set_error(e)
-      raise e
+      raise
     end
   end
 
@@ -72,7 +72,6 @@ class LibrarySyncConsumer < ApplicationConsumer
 
   def failed_sync_attributes(finished_processing_at)
     return {
-      started_processing_at: finished_processing_at,
       finished_processing_at:,
       waiting_time: finished_processing_at - @sync_job.created_at,
       processing_time: 0

--- a/app/consumers/library_sync_consumer.rb
+++ b/app/consumers/library_sync_consumer.rb
@@ -56,10 +56,32 @@ class LibrarySyncConsumer < ApplicationConsumer
       do_processing
       end_processing
     rescue StandardError => e
-      @sync_job&.status_failed!
+      mark_sync_job_failed
       Appsignal.set_error(e)
       raise e
     end
+  end
+
+  def mark_sync_job_failed
+    return if @sync_job.nil?
+
+    finished_processing_at = Time.current
+    @sync_job.update(failed_sync_attributes(finished_processing_at))
+    @sync_job.status_failed!
+  end
+
+  def failed_sync_attributes(finished_processing_at)
+    return {
+      started_processing_at: finished_processing_at,
+      finished_processing_at:,
+      waiting_time: finished_processing_at - @sync_job.created_at,
+      processing_time: 0
+    } if @sync_job.started_processing_at.nil?
+
+    {
+      finished_processing_at:,
+      processing_time: finished_processing_at - @sync_job.started_processing_at
+    }
   end
 
   # FOR TESTING FIFO PER USER

--- a/app/controllers/profiles/games_controller.rb
+++ b/app/controllers/profiles/games_controller.rb
@@ -68,7 +68,10 @@ module Profiles
     private
 
     def set_sync_jobs
-      @sync_jobs = @profile.user.sync_jobs.active.order(:created_at) if !@current_user.nil? && @profile == @current_user.profile
+      return if @current_user.nil? || @profile != @current_user.profile
+
+      @sync_jobs = @profile.user.sync_jobs.active.order(:created_at)
+      @failed_sync_jobs = @profile.user.sync_jobs.recent_failures.limit(3)
     end
 
     def game

--- a/app/models/sync_job.rb
+++ b/app/models/sync_job.rb
@@ -1,10 +1,13 @@
 # frozen_string_literal: true
+
+# Stores metadata for each library sync operation enqueued from API/plugin.
 class SyncJob < ApplicationRecord
   belongs_to :user
 
   enum status: { queued: "queued", running: "running", finished: "finished", failed: "failed", dead: "dead" }, _prefix: :status
 
-  scope :active, -> { where(status: %i[queued running failed]) }
+  scope :active, -> { where(status: %i[queued running]) }
+  scope :recent_failures, -> { where(status: %i[failed dead]).order(created_at: :desc) }
 
   def self.ransackable_attributes(_auth_object = nil)
     ["created_at", "finished_processing_at", "id", "name", "processing_time", "started_processing_at", "status", "updated_at", "user_id", "waiting_time"]

--- a/app/views/profiles/games/index.html.haml
+++ b/app/views/profiles/games/index.html.haml
@@ -1,13 +1,13 @@
-- unless @sync_jobs.nil? || @sync_jobs.count.zero?
+- if @sync_jobs&.any?
   .alert.alert-primary
-    = "There's a synchronisation still being processed:"
+    = "There's a synchronization still being processed:"
     .br
     - @sync_jobs.each do |sync_job|
       = "Registered: #{sync_job.created_at}, status: #{sync_job.status}."
       .br
-- unless @failed_sync_jobs.nil? || @failed_sync_jobs.count.zero?
+- if @failed_sync_jobs&.any?
   .alert.alert-danger
-    = "Some recent synchronisations failed:"
+    = "Some recent synchronizations failed:"
     .br
     - @failed_sync_jobs.each do |sync_job|
       = "Registered: #{sync_job.created_at}, status: #{sync_job.status}."

--- a/app/views/profiles/games/index.html.haml
+++ b/app/views/profiles/games/index.html.haml
@@ -5,6 +5,14 @@
     - @sync_jobs.each do |sync_job|
       = "Registered: #{sync_job.created_at}, status: #{sync_job.status}."
       .br
+- unless @failed_sync_jobs.nil? || @failed_sync_jobs.count.zero?
+  .alert.alert-danger
+    = "Some recent synchronisations failed:"
+    .br
+    - @failed_sync_jobs.each do |sync_job|
+      = "Registered: #{sync_job.created_at}, status: #{sync_job.status}."
+      .br
+    = "Please retry synchronization from the plugin."
 .row
   .col-12
     = render "search_form"


### PR DESCRIPTION
## Summary
- stop treating `failed` sync jobs as active/in-progress
- show recent failed/dead sync jobs in profile games view with a clear retry hint
- ensure failed jobs get finished timestamps/processing time in consumer failure path

## Outcome
- sync failures are visible to users instead of looking like stuck processing

Closes #47