### PR TITLE
Feat #62: robust sync jobs with payload diagnostics and chunking

### DIFF
--- a/app/consumers/library_sync_consumer.rb
+++ b/app/consumers/library_sync_consumer.rb
@@ -44,9 +44,7 @@ class LibrarySyncConsumer < ApplicationConsumer
     finished_processing_at = Time.current
     @sync_job.update(finished_processing_at:, processing_time: finished_processing_at - @sync_job.started_processing_at)
     @sync_job.status_finished!
-    # rubocop:disable Style/GlobalVars
-    $redis.expire("syncjob:#{@sync_job.id}", 1)
-    # rubocop:enable Style/GlobalVars
+    expire_sync_payload
   end
 
   def consume
@@ -56,31 +54,37 @@ class LibrarySyncConsumer < ApplicationConsumer
       do_processing
       end_processing
     rescue StandardError => e
-      mark_sync_job_failed
+      mark_sync_job_failed(e)
       Appsignal.set_error(e)
       raise
     end
   end
 
-  def mark_sync_job_failed
+  def mark_sync_job_failed(error)
     return if @sync_job.nil?
 
     finished_processing_at = Time.current
-    @sync_job.update(failed_sync_attributes(finished_processing_at))
+    attributes = {
+      finished_processing_at:,
+      error_message: error.full_message(highlight: false)
+    }
+
+    if @sync_job.started_processing_at.nil?
+      attributes[:waiting_time] = finished_processing_at - @sync_job.created_at
+      attributes[:processing_time] = 0
+    else
+      attributes[:processing_time] = finished_processing_at - @sync_job.started_processing_at
+    end
+
+    @sync_job.update(attributes)
     @sync_job.status_failed!
+    expire_sync_payload
   end
 
-  def failed_sync_attributes(finished_processing_at)
-    return {
-      finished_processing_at:,
-      waiting_time: finished_processing_at - @sync_job.created_at,
-      processing_time: 0
-    } if @sync_job.started_processing_at.nil?
-
-    {
-      finished_processing_at:,
-      processing_time: finished_processing_at - @sync_job.started_processing_at
-    }
+  def expire_sync_payload
+    # rubocop:disable Style/GlobalVars
+    $redis.expire("syncjob:#{@sync_job.id}", 1)
+    # rubocop:enable Style/GlobalVars
   end
 
   # FOR TESTING FIFO PER USER

--- a/app/controllers/api/v1/games.rb
+++ b/app/controllers/api/v1/games.rb
@@ -3,8 +3,13 @@
 module API
   module V1
     # Games API endpoint
+    # rubocop:disable Metrics/ClassLength
     class Games < Grape::API
       include API::V1::Defaults
+
+      MAX_SYNCJOB_PAYLOAD_BYTES = ENV.fetch("SYNCJOB_MAX_PAYLOAD_BYTES", 5.megabytes).to_i
+      MAX_SYNCJOB_GAMES_PER_JOB = ENV.fetch("SYNCJOB_MAX_GAMES_PER_JOB", 1_000).to_i
+
       resource :games do
         desc "Return all games"
         get "" do
@@ -14,16 +19,7 @@ module API
         desc "Register games"
         post "" do
           error! "Incorrect parameters, check for plugin updates" if params.dig("games", 0, "id").nil?
-          job = current_user.sync_jobs.create(name: "FullLibrarySyncJob")
-          # rubocop:disable Style/GlobalVars
-          $redis.set("syncjob:#{job.id}", params[:games].to_json)
-          # rubocop:enable Style/GlobalVars
-          Karafka.producer.produce_sync(
-            topic: "library.sync",
-            payload: { type: "full", current_user_id: current_user.id, job_id: job.id }.to_json,
-            key: current_user.id,
-            partition_key: current_user.id
-          )
+          enqueue_sync_jobs!(type: "full", base_job_name: "FullLibrarySyncJob", games: params[:games])
           GC.start
           status 202
         end
@@ -31,16 +27,7 @@ module API
         desc "Update games"
         put "" do
           error! "Incorrect parameters, check for plugin updates" if params.dig("games", 0, "id").nil?
-          job = current_user.sync_jobs.create(name: "PartialLibrarySyncJob")
-          # rubocop:disable Style/GlobalVars
-          $redis.set("syncjob:#{job.id}", params[:games].to_json)
-          # rubocop:enable Style/GlobalVars
-          Karafka.producer.produce_sync(
-            topic: "library.sync",
-            payload: { type: "partial", current_user_id: current_user.id, job_id: job.id }.to_json,
-            key: current_user.id,
-            partition_key: current_user.id
-          )
+          enqueue_sync_jobs!(type: "partial", base_job_name: "PartialLibrarySyncJob", games: params[:games])
           GC.start
           status 202
         end
@@ -48,16 +35,7 @@ module API
         desc "Delete games"
         put "delete" do
           error! "Incorrect parameters, check for plugin updates" if params.dig("games", 0, "id").nil?
-          job = current_user.sync_jobs.create(name: "DeleteGamesSyncJob")
-          # rubocop:disable Style/GlobalVars
-          $redis.set("syncjob:#{job.id}", params[:games].to_json)
-          # rubocop:enable Style/GlobalVars
-          Karafka.producer.produce_sync(
-            topic: "library.sync",
-            payload: { type: "delete", current_user_id: current_user.id, job_id: job.id }.to_json,
-            key: current_user.id,
-            partition_key: current_user.id
-          )
+          enqueue_sync_jobs!(type: "delete", base_job_name: "DeleteGamesSyncJob", games: params[:games])
           GC.start
           status 202
         end
@@ -79,6 +57,96 @@ module API
           status 202
         end
       end
+
+      helpers do
+        def enqueue_sync_jobs!(type:, base_job_name:, games:)
+          chunked_games = chunk_sync_payload(type, games)
+          total_chunks = chunked_games.size
+          chunked_games.each_with_index do |chunk_games, chunk_index|
+            enqueue_chunk_with_recovery(
+              chunk_games:,
+              metadata: {
+                type:,
+                base_job_name:,
+                total_chunks:,
+                chunk_index:
+              }
+            )
+          end
+        end
+
+        def chunk_sync_payload(type, games)
+          payload_json = games.to_json
+          payload_size = payload_json.bytesize
+
+          Rails.logger.debug { "[syncjob] type=#{type} user_id=#{current_user.id} payload_size_mb=#{(payload_size.to_f / 1024 / 1024).round(2)}" }
+
+          return [games] if payload_size <= MAX_SYNCJOB_PAYLOAD_BYTES
+
+          games.each_slice(MAX_SYNCJOB_GAMES_PER_JOB).to_a
+        end
+
+        def sync_type_for_chunk(type, chunk_index)
+          return type unless type == "full" && chunk_index.positive?
+
+          "partial"
+        end
+
+        def sync_job_name(base_job_name, total_chunks, chunk_index)
+          return base_job_name if total_chunks <= 1
+
+          "#{base_job_name}(chunk #{chunk_index + 1}/#{total_chunks})"
+        end
+
+        def enqueue_single_sync_job!(type:, chunk_games:, metadata:)
+          payload_json = chunk_games.to_json
+          job = create_sync_job(payload_size: payload_json.bytesize, **metadata)
+
+          persist_sync_payload(job, payload_json)
+          publish_sync_job(job, type)
+          job
+        end
+
+        def create_sync_job(base_job_name:, total_chunks:, chunk_index:, payload_size:)
+          current_user.sync_jobs.create!(
+            name: sync_job_name(base_job_name, total_chunks, chunk_index),
+            payload_size_bytes: payload_size,
+            payload_chunks: total_chunks,
+            payload_chunk_index: chunk_index
+          )
+        end
+
+        def persist_sync_payload(job, payload_json)
+          # rubocop:disable Style/GlobalVars
+          $redis.set("syncjob:#{job.id}", payload_json)
+          # rubocop:enable Style/GlobalVars
+        end
+
+        def publish_sync_job(job, type)
+          Karafka.producer.produce_sync(
+            topic: "library.sync",
+            payload: { type:, current_user_id: current_user.id, job_id: job.id }.to_json,
+            key: current_user.id,
+            partition_key: current_user.id
+          )
+        end
+
+        def enqueue_chunk_with_recovery(chunk_games:, metadata:)
+          job = enqueue_single_sync_job!(
+            type: sync_type_for_chunk(metadata[:type], metadata[:chunk_index]),
+            chunk_games:,
+            metadata: {
+              base_job_name: metadata[:base_job_name],
+              total_chunks: metadata[:total_chunks],
+              chunk_index: metadata[:chunk_index]
+            }
+          )
+        rescue StandardError => e
+          job&.update(status: :failed, error_message: e.full_message(highlight: false))
+          raise e
+        end
+      end
     end
+    # rubocop:enable Metrics/ClassLength
   end
 end

--- a/app/controllers/api/v1/games.rb
+++ b/app/controllers/api/v1/games.rb
@@ -82,8 +82,14 @@ module API
           Rails.logger.debug { "[syncjob] type=#{type} user_id=#{current_user.id} payload_size_mb=#{(payload_size.to_f / 1024 / 1024).round(2)}" }
 
           return [games] if payload_size <= MAX_SYNCJOB_PAYLOAD_BYTES
+          if type == "full"
+            error!(
+              "Full library sync payload exceeds #{MAX_SYNCJOB_PAYLOAD_BYTES} bytes. Please reduce sync payload size or increase server limit.",
+              413
+            )
+          end
 
-          games.each_slice(MAX_SYNCJOB_GAMES_PER_JOB).to_a
+          chunk_by_count_and_bytes(type, games)
         end
 
         def sync_type_for_chunk(type, chunk_index)
@@ -143,7 +149,44 @@ module API
           )
         rescue StandardError => e
           job&.update(status: :failed, error_message: e.full_message(highlight: false))
-          raise e
+          raise
+        end
+
+        def chunk_by_count_and_bytes(type, games)
+          chunks = []
+          current_chunk = []
+          current_chunk_bytes = 2 # JSON array brackets: []
+          games.each do |game|
+            game_json = game.to_json
+            game_bytes = json_entry_size(current_chunk, game_json)
+            current_chunk, current_chunk_bytes = roll_chunk_if_needed(chunks, current_chunk, current_chunk_bytes, game_bytes)
+            validate_single_game_payload_size!(type, game_json)
+            current_chunk << game
+            current_chunk_bytes += game_bytes
+          end
+          chunks << current_chunk if current_chunk.any?
+          chunks
+        end
+
+        def roll_chunk_if_needed(chunks, current_chunk, current_chunk_bytes, game_bytes)
+          return [current_chunk, current_chunk_bytes] unless current_chunk.any? && chunk_limit_reached?(current_chunk, current_chunk_bytes, game_bytes)
+
+          chunks << current_chunk
+          [[], 2]
+        end
+
+        def chunk_limit_reached?(chunk, chunk_bytes, next_game_bytes)
+          chunk.size >= MAX_SYNCJOB_GAMES_PER_JOB || (chunk_bytes + next_game_bytes > MAX_SYNCJOB_PAYLOAD_BYTES)
+        end
+
+        def json_entry_size(current_chunk, game_json)
+          game_json.bytesize + (current_chunk.empty? ? 0 : 1) # comma separator
+        end
+
+        def validate_single_game_payload_size!(type, game_json)
+          return unless game_json.bytesize + 2 > MAX_SYNCJOB_PAYLOAD_BYTES
+
+          error!("A single game payload is too large for #{type} sync (#{MAX_SYNCJOB_PAYLOAD_BYTES} bytes limit).", 413)
         end
       end
     end

--- a/app/models/sync_job.rb
+++ b/app/models/sync_job.rb
@@ -1,16 +1,33 @@
 # frozen_string_literal: true
 
-# Stores metadata for each library sync operation enqueued from API/plugin.
+# Tracks lifecycle and diagnostics for sync operations triggered by clients.
 class SyncJob < ApplicationRecord
   belongs_to :user
 
+  RANSACKABLE_ATTRIBUTES = [
+    "created_at",
+    "error_message",
+    "finished_processing_at",
+    "id",
+    "name",
+    "payload_chunk_index",
+    "payload_chunks",
+    "payload_size_bytes",
+    "processing_time",
+    "started_processing_at",
+    "status",
+    "updated_at",
+    "user_id",
+    "waiting_time"
+  ].freeze
+
   enum status: { queued: "queued", running: "running", finished: "finished", failed: "failed", dead: "dead" }, _prefix: :status
 
-  scope :active, -> { where(status: %i[queued running]) }
+  scope :active, -> { where(status: %i[queued running failed]) }
   scope :recent_failures, -> { where(status: %i[failed dead]).order(created_at: :desc) }
 
   def self.ransackable_attributes(_auth_object = nil)
-    ["created_at", "finished_processing_at", "id", "name", "processing_time", "started_processing_at", "status", "updated_at", "user_id", "waiting_time"]
+    RANSACKABLE_ATTRIBUTES
   end
 
   def self.ransackable_associations(_auth_object = nil)

--- a/db/migrate/20260302183000_add_sync_job_diagnostics.rb
+++ b/db/migrate/20260302183000_add_sync_job_diagnostics.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Adds diagnostics fields used to inspect sync payload and failure details.
+class AddSyncJobDiagnostics < ActiveRecord::Migration[7.1]
+  def change
+    change_table :sync_jobs, bulk: true do |t|
+      t.bigint :payload_size_bytes, null: false, default: 0
+      t.integer :payload_chunks, null: false, default: 1
+      t.integer :payload_chunk_index, null: false, default: 0
+      t.text :error_message
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -375,6 +375,10 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_02_190000) do
     t.datetime "finished_processing_at"
     t.integer "waiting_time"
     t.integer "processing_time"
+    t.bigint "payload_size_bytes", default: 0, null: false
+    t.integer "payload_chunks", default: 1, null: false
+    t.integer "payload_chunk_index", default: 0, null: false
+    t.text "error_message"
     t.index ["created_at", "status"], name: "index_sync_jobs_on_created_at_and_status"
     t.index ["created_at"], name: "index_sync_jobs_on_created_at"
     t.index ["user_id"], name: "index_sync_jobs_on_user_id"


### PR DESCRIPTION
## Summary
- add sync job diagnostics fields: payload size, chunk metadata, and error message
- persist failure details from consumer exceptions to `sync_jobs.error_message`
- add payload-size logging for sync requests
- split oversized sync payloads into chunked jobs
- for oversized full sync, run first chunk as `full`, follow-up chunks as `partial`

## Database
- migration: `AddSyncJobDiagnostics`

Closes #62