### PR TITLE
Fix #86: graceful IGDB and playlist item error handling

### DIFF
--- a/app/controllers/profiles/games_controller.rb
+++ b/app/controllers/profiles/games_controller.rb
@@ -63,7 +63,7 @@ module Profiles
         if updated
           format.turbo_stream { redirect_to profile_game_path(@profile, @game) }
         else
-          format.turbo_stream { render turbo_stream: turbo_stream.replace("game_errors", partial: "game_errors") }
+          format.turbo_stream { render turbo_stream: turbo_stream.replace("profile_errors", partial: "game_errors") }
         end
       end
     end

--- a/app/controllers/profiles/games_controller.rb
+++ b/app/controllers/profiles/games_controller.rb
@@ -49,11 +49,17 @@ module Profiles
       @igdb_cache = @game.igdb_cache || @game.build_igdb_cache
     end
 
+    # rubocop:disable Metrics/AbcSize, Metrics/BlockLength
     def update
       should_update_igdb_cache = igdb_cache_update_requested?
       igdb_cache = resolved_igdb_cache_from_params if should_update_igdb_cache
       respond_to do |format|
-        updated = should_update_igdb_cache ? @game.update(igdb_cache:) : true
+        if should_update_igdb_cache && igdb_cache_not_found?(igdb_cache)
+          add_igdb_not_found_error(@game, params.dig(:game, :igdb_cache, :igdb_id))
+          updated = false
+        else
+          updated = should_update_igdb_cache ? @game.update(igdb_cache:) : true
+        end
         if updated
           format.turbo_stream { redirect_to profile_game_path(@profile, @game) }
         else
@@ -61,6 +67,7 @@ module Profiles
         end
       end
     end
+    # rubocop:enable Metrics/AbcSize, Metrics/BlockLength
 
     def destroy
     end
@@ -243,6 +250,14 @@ module Profiles
       return nil if igdb_id.blank?
 
       IgdbCache.get_by_igdb_id(igdb_id)
+    end
+
+    def igdb_cache_not_found?(igdb_cache)
+      params.dig(:game, :igdb_cache, :igdb_id).present? && igdb_cache.nil?
+    end
+
+    def add_igdb_not_found_error(record, igdb_id)
+      record.errors.add(:base, "IGDB entry was not found for ID #{igdb_id}.")
     end
 
     def set_games

--- a/app/controllers/profiles/playlists/playlist_items_controller.rb
+++ b/app/controllers/profiles/playlists/playlist_items_controller.rb
@@ -4,6 +4,7 @@
 module Profiles
   module Playlists
     # Profiles playlist_items controller
+    # rubocop:disable Metrics/ClassLength
     class PlaylistItemsController < BaseController
       before_action :check_current_user_playlist, only: %i[new create edit update destroy reorder]
       before_action :playlist_item, only: %i[edit update destroy]
@@ -18,7 +19,7 @@ module Profiles
         @igdb_cache = @playlist_item.igdb_cache || @playlist_item.build_igdb_cache
       end
 
-      # rubocop:disable Metrics/AbcSize
+      # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity, Metrics/BlockLength
       def create
         igdb_id = params.dig(:playlist_item, :igdb_cache, :igdb_id)
         igdb_cache = nil
@@ -27,12 +28,21 @@ module Profiles
         next_order = (@playlist.playlist_items.maximum(:order) || 0) + 1
         @playlist_item = @playlist.playlist_items.new(order: next_order, igdb_cache:)
         respond_to do |format|
+          if igdb_id.present? && igdb_cache.nil?
+            add_igdb_not_found_error(@playlist_item, igdb_id)
+            format.turbo_stream { render turbo_stream: turbo_stream.replace("playlist_item_errors", partial: "playlist_item_errors") }
+            next
+          end
+
           if @playlist_item.save
             PlaylistItem.move_to_position!(@playlist, @playlist_item.id, desired_position) if desired_position.present?
             format.turbo_stream { redirect_to profile_playlist_path(@profile, @playlist) }
           else
             format.turbo_stream { render turbo_stream: turbo_stream.replace("playlist_item_errors", partial: "playlist_item_errors") }
           end
+        rescue ActiveRecord::RecordNotUnique
+          @playlist_item.errors.add(:base, "This game or order already exists in this playlist.")
+          format.turbo_stream { render turbo_stream: turbo_stream.replace("playlist_item_errors", partial: "playlist_item_errors") }
         end
       end
 
@@ -42,15 +52,24 @@ module Profiles
         igdb_cache = IgdbCache.get_by_igdb_id(igdb_id) if igdb_id.present?
         desired_position = parse_position(playlist_item_params[:order])
         respond_to do |format|
+          if igdb_id.present? && igdb_cache.nil?
+            add_igdb_not_found_error(@playlist_item, igdb_id)
+            format.turbo_stream { render turbo_stream: turbo_stream.replace("playlist_item_errors", partial: "playlist_item_errors") }
+            next
+          end
+
           if @playlist_item.update(igdb_cache:)
             PlaylistItem.move_to_position!(@playlist, @playlist_item.id, desired_position) if desired_position.present?
             format.turbo_stream { redirect_to profile_playlist_path(@profile, @playlist) }
           else
             format.turbo_stream { render turbo_stream: turbo_stream.replace("playlist_item_errors", partial: "playlist_item_errors") }
           end
+        rescue ActiveRecord::RecordNotUnique
+          @playlist_item.errors.add(:base, "This game or order already exists in this playlist.")
+          format.turbo_stream { render turbo_stream: turbo_stream.replace("playlist_item_errors", partial: "playlist_item_errors") }
         end
       end
-      # rubocop:enable all
+      # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity, Metrics/BlockLength
 
       def destroy
         @playlist_item.destroy!
@@ -95,6 +114,10 @@ module Profiles
         parsed.positive? ? parsed : nil
       rescue ArgumentError, TypeError
         nil
+      end
+
+      def add_igdb_not_found_error(record, igdb_id)
+        record.errors.add(:base, "IGDB entry was not found for ID #{igdb_id}.")
       end
 
       def redirect_to_playlist_with_notice

--- a/app/models/playlist_item.rb
+++ b/app/models/playlist_item.rb
@@ -4,7 +4,11 @@
 class PlaylistItem < ApplicationRecord
   belongs_to :playlist
   belongs_to :igdb_cache
+
+  validates :igdb_cache_id, uniqueness: { scope: :playlist_id }
   validates :order, presence: true
+  validates :order, uniqueness: { scope: :playlist_id }
+
   after_commit :normalize_playlist_orders_after_create, on: :create
   after_commit :normalize_playlist_orders_after_update, on: :update
   after_commit :normalize_playlist_orders_after_destroy, on: :destroy

--- a/app/services/igdb_get_game.rb
+++ b/app/services/igdb_get_game.rb
@@ -38,7 +38,10 @@ class IgdbGetGame
     
     response = http.request(request)
 
-    parsed_response = JSON.parse(response.body.force_encoding("UTF-8"))
+    body = response.body
+    return nil if body.blank?
+
+    parsed_response = JSON.parse(body.force_encoding("UTF-8"))
     idgb_game = parsed_response.is_a?(Array) ? parsed_response.first : nil
     return nil if idgb_game.nil?
 
@@ -48,7 +51,7 @@ class IgdbGetGame
     IgdbCache.find_or_create_by(igdb_id:) do |cache|
       cache.name = idgb_game["name"]
     end
-  rescue JSON::ParserError
+  rescue JSON::ParserError, TypeError
     nil
   end
   # rubocop:enable all

--- a/spec/controllers/profiles/playlists/playlist_items_controller_spec.rb
+++ b/spec/controllers/profiles/playlists/playlist_items_controller_spec.rb
@@ -3,6 +3,60 @@
 require "rails_helper"
 
 RSpec.describe Profiles::Playlists::PlaylistItemsController do
+  describe "POST #create" do
+    let(:owner) { create(:user) }
+    let(:playlist) { create(:playlist, user: owner) }
+
+    before { sign_in owner }
+
+    it "renders inline error when IGDB id is not found" do
+      allow(IgdbCache).to receive(:get_by_igdb_id).with("999999").and_return(nil)
+
+      post :create,
+           params: {
+             profile_id: owner.profile.slug,
+             playlist_id: playlist.id,
+             playlist_item: {
+               order: 1,
+               igdb_cache: { igdb_id: "999999" }
+             }
+           },
+           format: :turbo_stream
+
+      expect(response).to have_http_status(:ok)
+      expect(response.media_type).to eq("text/vnd.turbo-stream.html")
+      expect(response.body).to include("IGDB entry was not found for ID 999999.")
+    end
+  end
+
+  describe "PATCH #update" do
+    let(:owner) { create(:user) }
+    let(:playlist) { create(:playlist, user: owner) }
+    let(:playlist_item) { create(:playlist_item, playlist:, order: 1) }
+
+    before { sign_in owner }
+
+    it "renders inline error when IGDB id is not found" do
+      allow(IgdbCache).to receive(:get_by_igdb_id).with("888888").and_return(nil)
+
+      patch :update,
+            params: {
+              profile_id: owner.profile.slug,
+              playlist_id: playlist.id,
+              id: playlist_item.id,
+              playlist_item: {
+                order: 1,
+                igdb_cache: { igdb_id: "888888" }
+              }
+            },
+            format: :turbo_stream
+
+      expect(response).to have_http_status(:ok)
+      expect(response.media_type).to eq("text/vnd.turbo-stream.html")
+      expect(response.body).to include("IGDB entry was not found for ID 888888.")
+    end
+  end
+
   describe "PATCH #reorder" do
     let(:owner) { create(:user) }
     let(:playlist) { create(:playlist, user: owner) }

--- a/spec/models/playlist_item_spec.rb
+++ b/spec/models/playlist_item_spec.rb
@@ -3,6 +3,29 @@
 require "rails_helper"
 
 RSpec.describe PlaylistItem do
+  describe "validations" do
+    it "enforces unique igdb_cache per playlist" do
+      playlist = create(:playlist)
+      igdb_cache = create(:igdb_cache)
+      create(:playlist_item, playlist:, igdb_cache:, order: 1)
+
+      duplicate = build(:playlist_item, playlist:, igdb_cache:, order: 2)
+
+      expect(duplicate).not_to be_valid
+      expect(duplicate.errors[:igdb_cache_id]).to include("has already been taken")
+    end
+
+    it "enforces unique order per playlist" do
+      playlist = create(:playlist)
+      create(:playlist_item, playlist:, order: 1)
+
+      duplicate_order = build(:playlist_item, playlist:, order: 1)
+
+      expect(duplicate_order).not_to be_valid
+      expect(duplicate_order.errors[:order]).to include("has already been taken")
+    end
+  end
+
   describe ".reorder_for_playlist!" do
     it "reorders deterministically using current order for omitted ids" do
       playlist = create(:playlist)


### PR DESCRIPTION
## Summary
- handle IGDB API empty/invalid responses safely in `IgdbGetGame`
- surface clear error when IGDB ID is not found during game edit
- surface clear error when IGDB ID is not found during playlist item create/update
- add model-level playlist item uniqueness validation for `(playlist_id, igdb_cache_id)` and `(playlist_id, order)`
- catch `RecordNotUnique` in playlist item create/update and render user-facing error

## Notes
- this addresses the stability/error-handling subset of #86
- larger UX/feature items from #86 can follow in separate PRs

Partially covers #86