### PR TITLE
Feat #31: split profile privacy and game library privacy

### DIFF
--- a/app/controllers/profiles/base_controller.rb
+++ b/app/controllers/profiles/base_controller.rb
@@ -86,6 +86,10 @@ module Profiles
       return false unless current_user
       return false if @profile.privacy_private?
 
+      accepted_friendship_with_profile_user?
+    end
+
+    def accepted_friendship_with_profile_user?
       Friend.where(status: :accepted).exists?(
         ["(inviter_id = :current_user_id AND invitee_id = :profile_user_id) OR " \
          "(invitee_id = :current_user_id AND inviter_id = :profile_user_id)",

--- a/app/controllers/profiles/games_controller.rb
+++ b/app/controllers/profiles/games_controller.rb
@@ -29,6 +29,8 @@ module Profiles
     }.freeze
 
     before_action :game, only: %i[show edit update destroy]
+    before_action :check_game_library_access_profile, only: %i[index show]
+    skip_before_action :check_general_access_profile, only: %i[index show]
 
     def index
       set_games
@@ -66,6 +68,30 @@ module Profiles
     end
 
     private
+
+    def check_game_library_access_profile
+      set_profile
+      return if profile_own?
+      return if @profile.game_library_privacy_public?
+      return if @profile.game_library_privacy_friendly? && game_library_friend?
+
+      redirect_to_profiles_with_notice
+    rescue ActiveRecord::RecordNotFound
+      redirect_to_profiles_with_notice
+    end
+
+    def game_library_friend?
+      return false unless current_user
+
+      Friend.where(status: :accepted).exists?(
+        ["(inviter_id = :current_user_id AND invitee_id = :profile_user_id) OR " \
+         "(invitee_id = :current_user_id AND inviter_id = :profile_user_id)",
+         {
+           current_user_id: current_user.id,
+           profile_user_id: @profile.user_id
+         }]
+      )
+    end
 
     def set_sync_jobs
       @sync_jobs = @profile.user.sync_jobs.active.order(:created_at) if !@current_user.nil? && @profile == @current_user.profile

--- a/app/controllers/profiles/games_controller.rb
+++ b/app/controllers/profiles/games_controller.rb
@@ -28,8 +28,8 @@ module Profiles
       "status_desc" => "(SELECT LOWER(completion_statuses.name) FROM completion_statuses WHERE completion_statuses.id = games.completion_status_id) DESC NULLS LAST, LOWER(games.name) ASC"
     }.freeze
 
-    before_action :game, only: %i[show edit update destroy]
     before_action :check_game_library_access_profile, only: %i[index show]
+    before_action :game, only: %i[show edit update destroy]
     skip_before_action :check_general_access_profile, only: %i[index show]
 
     def index
@@ -83,14 +83,7 @@ module Profiles
     def game_library_friend?
       return false unless current_user
 
-      Friend.where(status: :accepted).exists?(
-        ["(inviter_id = :current_user_id AND invitee_id = :profile_user_id) OR " \
-         "(invitee_id = :current_user_id AND inviter_id = :profile_user_id)",
-         {
-           current_user_id: current_user.id,
-           profile_user_id: @profile.user_id
-         }]
-      )
+      accepted_friendship_with_profile_user?
     end
 
     def set_sync_jobs
@@ -98,8 +91,11 @@ module Profiles
     end
 
     def game
+      set_profile if @profile.blank?
       @game = @profile.user.games.find_by(id: params[:id])
       @game ||= redirect_to_games_with_notice # defined in app controller
+    rescue ActiveRecord::RecordNotFound
+      redirect_to_games_with_notice
     end
 
     def filter_games

--- a/app/controllers/profiles/profiles_controller.rb
+++ b/app/controllers/profiles/profiles_controller.rb
@@ -73,7 +73,7 @@ module Profiles
     end
 
     def profile_params
-      params.require(:profile).permit(:name, :privacy, :vanity_url)
+      params.require(:profile).permit(:name, :privacy, :game_library_privacy, :vanity_url)
     end
 
     def set_profile

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -8,9 +8,10 @@ class Profile < ApplicationRecord
   belongs_to :user
 
   enum privacy: { private: "private", public: "public", friendly: "friendly" }, _prefix: :privacy
+  enum game_library_privacy: { private: "private", public: "public", friendly: "friendly" }, _prefix: :game_library_privacy
 
   def self.ransackable_attributes(_auth_object = nil)
-    ["created_at", "id", "name", "privacy", "slug", "updated_at", "user_id", "vanity_url"]
+    ["created_at", "game_library_privacy", "id", "name", "privacy", "slug", "updated_at", "user_id", "vanity_url"]
   end
 
 def self.ransackable_associations(_auth_object = nil)

--- a/app/views/profiles/games/_game_details.haml
+++ b/app/views/profiles/games/_game_details.haml
@@ -16,12 +16,13 @@
 - install_size_label = game.install_size.present? ? number_to_human_size(game.install_size) : "N/A"
 - last_size_scan_label = game.last_size_scan_date ? "#{time_ago_in_words(game.last_size_scan_date)} ago" : "N/A"
 - recent_activity_label = game.recent_activity ? "#{time_ago_in_words(game.recent_activity)} ago" : "N/A"
+- own_profile = @profile == current_user&.profile
 
 .game-details
   .game-details__header.mb-3
     .d-flex.flex-wrap.align-items-center.gap-2.gap-md-3
       %h1.game-details__title.mb-0
-        - if game.playnite_id && game.is_installed && @profile == current_user&.profile
+        - if game.playnite_id && game.is_installed && own_profile
           = link_to "playnite://playnite/start/#{game.playnite_id}", class: "game-details__play", title: "Play" do
             %i.bi.bi-play-fill
         = game.name
@@ -184,39 +185,40 @@
               - else
                 N/A
 
-  .accordion.game-details__accordion.mt-3#gameTechnicalDetails
-    .accordion-item
-      %h2.accordion-header#gameTechnicalHeading
-        %button.accordion-button.collapsed{type: "button", data: { bs_toggle: "collapse", bs_target: "#gameTechnicalCollapse" }, aria: { expanded: "false", controls: "gameTechnicalCollapse" }}
-          Technical Details
-      .accordion-collapse.collapse#gameTechnicalCollapse{aria: { labelledby: "gameTechnicalHeading" }, data: { bs_parent: "#gameTechnicalDetails" }}
-        .accordion-body
-          %dl.game-details__list
-            %dt Game ID
-            %dd= game.game_id || "N/A"
-            %dt Playnite ID
-            %dd= game.playnite_id || "N/A"
-            %dt Plugin ID
-            %dd= game.plugin_id || "N/A"
-            %dt Sorting name
-            %dd= game.sorting_name || "N/A"
-            %dt Hidden
-            %dd= game.hidden ? "Yes" : "No"
-            %dt Include library plugin action
-            %dd= game.include_library_plugin_action ? "Yes" : "No"
-            %dt Install directory
-            %dd= game.install_directory || "N/A"
-            %dt Manual
-            %dd= game.manual || "N/A"
-            %dt Game started script
-            %dd= game.game_started_script || "N/A"
-            %dt Pre script
-            %dd= game.pre_script || "N/A"
-            %dt Post script
-            %dd= game.post_script || "N/A"
-            %dt Use global game started script
-            %dd= game.use_global_game_started_script ? "Yes" : "No"
-            %dt Use global pre script
-            %dd= game.use_global_pre_script ? "Yes" : "No"
-            %dt Use global post script
-            %dd= game.use_global_post_script ? "Yes" : "No"
+  - if own_profile
+    .accordion.game-details__accordion.mt-3#gameTechnicalDetails
+      .accordion-item
+        %h2.accordion-header#gameTechnicalHeading
+          %button.accordion-button.collapsed{type: "button", data: { bs_toggle: "collapse", bs_target: "#gameTechnicalCollapse" }, aria: { expanded: "false", controls: "gameTechnicalCollapse" }}
+            Technical Details
+        .accordion-collapse.collapse#gameTechnicalCollapse{aria: { labelledby: "gameTechnicalHeading" }, data: { bs_parent: "#gameTechnicalDetails" }}
+          .accordion-body
+            %dl.game-details__list
+              %dt Game ID
+              %dd= game.game_id || "N/A"
+              %dt Playnite ID
+              %dd= game.playnite_id || "N/A"
+              %dt Plugin ID
+              %dd= game.plugin_id || "N/A"
+              %dt Sorting name
+              %dd= game.sorting_name || "N/A"
+              %dt Hidden
+              %dd= game.hidden ? "Yes" : "No"
+              %dt Include library plugin action
+              %dd= game.include_library_plugin_action ? "Yes" : "No"
+              %dt Install directory
+              %dd= game.install_directory || "N/A"
+              %dt Manual
+              %dd= game.manual || "N/A"
+              %dt Game started script
+              %dd= game.game_started_script || "N/A"
+              %dt Pre script
+              %dd= game.pre_script || "N/A"
+              %dt Post script
+              %dd= game.post_script || "N/A"
+              %dt Use global game started script
+              %dd= game.use_global_game_started_script ? "Yes" : "No"
+              %dt Use global pre script
+              %dd= game.use_global_pre_script ? "Yes" : "No"
+              %dt Use global post script
+              %dd= game.use_global_post_script ? "Yes" : "No"

--- a/app/views/profiles/profiles/_form.html.haml
+++ b/app/views/profiles/profiles/_form.html.haml
@@ -18,6 +18,11 @@
       = f.select :privacy, Profile.privacies.keys.map { |w| [w.humanize, w] }, {}, { class: "form-select", "aria-describedby" => "privacy_help" }
       .form-text#privacy_help Private: hidden. Public: visible to everyone. Friendly: share profile URL and allow invites.
 
+    .col-12
+      = f.label :game_library_privacy, class: "form-label"
+      = f.select :game_library_privacy, Profile.game_library_privacies.keys.map { |w| [w.humanize, w] }, {}, { class: "form-select", "aria-describedby" => "game_library_privacy_help" }
+      .form-text#game_library_privacy_help Controls who can see your games library page.
+
   .d-flex.flex-wrap.justify-content-end.gap-2.mt-3
     = link_to "Back", profile_path(@profile), class: "btn btn-outline-secondary"
     = f.submit "Save profile", class: "btn btn-primary"

--- a/app/views/profiles/profiles/show.html.haml
+++ b/app/views/profiles/profiles/show.html.haml
@@ -19,6 +19,9 @@
             %span.profiles-show-badge
               Privacy:
               %strong.ms-1= @profile.privacy.humanize
+            %span.profiles-show-badge
+              Games privacy:
+              %strong.ms-1= @profile.game_library_privacy.humanize
             - if @profile.vanity_url.present?
               %span.profiles-show-badge
                 Vanity:
@@ -74,6 +77,9 @@
 
           %dt.col-5.col-md-4.text-muted Privacy
           %dd.col-7.col-md-8= @profile.privacy.humanize
+
+          %dt.col-5.col-md-4.text-muted Games privacy
+          %dd.col-7.col-md-8= @profile.game_library_privacy.humanize
 
           %dt.col-5.col-md-4.text-muted Member since
           %dd.col-7.col-md-8= time_ago_in_words(@profile.created_at) + " ago"

--- a/db/migrate/20260302190000_add_game_library_privacy_to_profiles.rb
+++ b/db/migrate/20260302190000_add_game_library_privacy_to_profiles.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Splits profile visibility into basic profile privacy and games library privacy.
+class AddGameLibraryPrivacyToProfiles < ActiveRecord::Migration[7.1]
+  def up
+    add_column :profiles, :game_library_privacy, :profile_privacy, default: "private", null: false
+    execute <<~SQL.squish
+      UPDATE profiles
+      SET game_library_privacy = privacy
+      WHERE game_library_privacy IS NULL OR game_library_privacy = 'private'
+    SQL
+  end
+
+  def down
+    remove_column :profiles, :game_library_privacy
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -375,10 +375,6 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_02_190000) do
     t.datetime "finished_processing_at"
     t.integer "waiting_time"
     t.integer "processing_time"
-    t.bigint "payload_size_bytes", default: 0, null: false
-    t.integer "payload_chunks", default: 1, null: false
-    t.integer "payload_chunk_index", default: 0, null: false
-    t.text "error_message"
     t.index ["created_at", "status"], name: "index_sync_jobs_on_created_at_and_status"
     t.index ["created_at"], name: "index_sync_jobs_on_created_at"
     t.index ["user_id"], name: "index_sync_jobs_on_user_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_03_02_143100) do
+ActiveRecord::Schema[7.1].define(version: 2026_03_02_190000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -312,6 +312,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_02_143100) do
     t.string "slug"
     t.enum "privacy", default: "private", enum_type: "profile_privacy"
     t.string "vanity_url"
+    t.enum "game_library_privacy", default: "private", null: false, enum_type: "profile_privacy"
     t.index ["privacy", "name"], name: "index_profiles_on_privacy_and_name"
     t.index ["slug"], name: "index_profiles_on_slug", unique: true
     t.index ["user_id"], name: "index_profiles_on_user_id"
@@ -374,6 +375,10 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_02_143100) do
     t.datetime "finished_processing_at"
     t.integer "waiting_time"
     t.integer "processing_time"
+    t.bigint "payload_size_bytes", default: 0, null: false
+    t.integer "payload_chunks", default: 1, null: false
+    t.integer "payload_chunk_index", default: 0, null: false
+    t.text "error_message"
     t.index ["created_at", "status"], name: "index_sync_jobs_on_created_at_and_status"
     t.index ["created_at"], name: "index_sync_jobs_on_created_at"
     t.index ["user_id"], name: "index_sync_jobs_on_user_id"


### PR DESCRIPTION
## Summary
- add `profiles.game_library_privacy` enum column
- backfill new game-library privacy from existing `profiles.privacy`
- enforce game-library access separately in `Profiles::GamesController`
- keep profile-level privacy behavior for profile pages
- expose new game-library privacy setting in profile edit form and profile details

## Database
- migration: `AddGameLibraryPrivacyToProfiles`

Partially covers #31